### PR TITLE
Add support for Typo3 ^8.6.1 and ^8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,20 @@
 language: php
 matrix:
     include:
-        - php: 5.6.30
         - php: 7.0
+          env: deps=high
+        - php: 7.0
+          env: deps=low
         - php: 7.1
+          env: deps=low
+        - php: 7.1
+          env: deps=high
     fast_finish: true
+
+## Cache composer bits
+cache:
+  directories:
+    - $HOME/.composer/cache/files
 
 env:
   global:
@@ -24,7 +34,7 @@ before_install:
   - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 install:
-  - composer install
+  - if [ "$deps" = "low" ]; then composer --prefer-lowest --prefer-stable update; else composer update; fi;
 
 script:
   - .Build/bin/phpunit --coverage-clover=coverage.clover

--- a/Tests/RedisLockStrategyTest.php
+++ b/Tests/RedisLockStrategyTest.php
@@ -31,8 +31,8 @@ namespace Tourstream\RedisLockStrategy\Tests;
  ***************************************************************/
 
 use TYPO3\CMS\Core\Locking\LockFactory;
-use TYPO3\CMS\Core\Tests\FunctionalTestCase;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
  * @author Alexander Miehe <alexander.miehe@tourstream.eu>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "tourstream/typo3-redis-lock-strategy",
     "type": "typo3-cms-extension",
     "license": "GPL-3.0+",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "authors": [
         {
             "name": "Alexander Miehe",
@@ -10,11 +10,12 @@
         }
     ],
     "require": {
-        "typo3/cms": "^7.6.0",
-        "php": "^5.6|^7.0"
+        "typo3/cms": "^8.6.1||^8.7",
+        "php": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7",
+        "typo3/testing-framework": "^1.0"
     },
     "replace": {
         "redis_lock_strategy": "self.version"
@@ -39,11 +40,7 @@
     },
     "config": {
         "vendor-dir": ".Build/vendor",
-        "bin-dir": ".Build/bin",
-        "preferred-install": {
-            "typo3/cms": "source",
-            "*": "dist"
-        }
+        "bin-dir": ".Build/bin"
     },
     "extra": {
         "typo3/cms": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,7 @@
 <phpunit
 	backupGlobals="true"
 	backupStaticAttributes="false"
-	bootstrap=".Build/vendor/typo3/cms/typo3/sysext/core/Build/FunctionalTestsBootstrap.php"
+	bootstrap=".Build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
 	colors="true"
 	convertErrorsToExceptions="true"
 	convertWarningsToExceptions="true"


### PR DESCRIPTION
* lower support is not possible because the testing framework use a method which is not existing in lower versions