### PR TITLE
[BUGFIX] Require the core base package only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: php
 matrix:
     include:
-        - php: 7.0
+        - php: 7.1
           env: deps=high
-        - php: 7.0
-          env: deps=low
         - php: 7.1
           env: deps=low
-        - php: 7.1
+        - php: 7.2
+          env: deps=low
+        - php: 7.2
           env: deps=high
     fast_finish: true
 

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,9 @@
         }
     ],
     "require": {
-        "typo3/cms": "^8.6.1||^8.7",
-        "php": "^7.0"
+        "typo3/cms-core": "^8.6.1 || ^8.7 || ^9.0",
+        "php": "^7.0",
+        "ext-redis": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "ext-redis": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
-        "typo3/testing-framework": "^1.0"
+        "phpunit/phpunit": "^7.0",
+        "typo3/testing-framework": "^4.0"
     },
     "replace": {
         "redis_lock_strategy": "self.version"
@@ -28,8 +28,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tourstream\\RedisLockStrategy\\Tests\\": "Tests/",
-            "TYPO3\\CMS\\Core\\Tests\\": ".Build/vendor/typo3/cms/typo3/sysext/core/Tests/"
+            "Tourstream\\RedisLockStrategy\\Tests\\": "Tests/"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "typo3/cms-core": "^8.6.1 || ^8.7 || ^9.0",
-        "php": "^7.0",
+        "php": "^7.1",
         "ext-redis": "*"
     },
     "require-dev": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,7 +26,7 @@ $EM_CONF[$_EXTKEY] = [
         [
             'depends'   =>
                 [
-                    'typo3' => '8.6.1-8.7.99',
+                    'typo3' => '8.6.1-9.5.99',
                 ],
             'conflicts' =>
                 [


### PR DESCRIPTION
In order to use native composer packages only, this change is required,
otherwise any TYPO3 installation via composer installs the whole
TYPO3 Core.